### PR TITLE
Change repository due to docker rate limitations

### DIFF
--- a/.pendingremake/booksonic.yml
+++ b/.pendingremake/booksonic.yml
@@ -16,7 +16,7 @@
         pgrole: 'booksonic'
         intport: '4040'
         extport: '4050'
-        image: 'linuxserver/booksonic'
+        image: 'ghcr.io/linuxserver/booksonic'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/ddclient.yml
+++ b/.pendingremake/ddclient.yml
@@ -15,7 +15,7 @@
         pgrole: 'ddclient'
         intport: '0'
         extport: '0'
-        image: 'linuxserver/ddclient'
+        image: 'ghcr.io/linuxserver/ddclient'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/deluge.yml
+++ b/.pendingremake/deluge.yml
@@ -19,7 +19,7 @@
         extport2: '58846'
         intport3: '58946'
         extport3: '58946'
-        image: 'linuxserver/deluge'
+        image: 'ghcr.io/linuxserver/deluge'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/domoticz.yml
+++ b/.pendingremake/domoticz.yml
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Title:      PlexGuide (linuxserver/domoticz)
+# Title:      PlexGuide (ghcr.io/linuxserver/domoticz)
 # Author(s):  Admin9705
 # URL:        https://plexguide.com - http://github.plexguide.com
 # GNU:        General Public License v3.0
@@ -20,7 +20,7 @@
         intport3: '1443/tcp'
         extport3: '1443'
 		
-        image: 'linuxserver/domoticz:stable'
+        image: 'ghcr.io/linuxserver/domoticz:stable'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/duplicati.yml
+++ b/.pendingremake/duplicati.yml
@@ -15,7 +15,7 @@
         pgrole: 'duplicati'
         intport: '8200'
         extport: '8200'
-        image: 'linuxserver/duplicati'
+        image: 'ghcr.io/linuxserver/duplicati'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/gazee.yml
+++ b/.pendingremake/gazee.yml
@@ -16,7 +16,7 @@
         pgrole: "gazee"
         intport: "4242"
         extport: "4242"
-        image: "linuxserver/gazee"
+        image: "ghcr.io/linuxserver/gazee"
 
     - name: 'Including cron job'
       include_tasks: '/opt/communityapps/apps/_core.yml'

--- a/.pendingremake/headphones.yml
+++ b/.pendingremake/headphones.yml
@@ -15,7 +15,7 @@
         pgrole: 'headphones'
         intport: '8181'
         extport: '8281'
-        image: 'linuxserver/headphones'
+        image: 'ghcr.io/linuxserver/headphones'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/heimdall.yml
+++ b/.pendingremake/heimdall.yml
@@ -16,7 +16,7 @@
         pgrole: 'heimdall'
         intport: '443'
         extport: '1111'
-        image: 'linuxserver/heimdall'
+        image: 'ghcr.io/linuxserver/heimdall'
 
     # CORE (MANDATORY) ############################################################ 
     - name: 'Including cron job'

--- a/.pendingremake/htpcmanager.yml
+++ b/.pendingremake/htpcmanager.yml
@@ -15,7 +15,7 @@
         pgrole: 'htpcmanager'
         intport: '8085'
         extport: '8085'
-        image: 'linuxserver/htpcmanager'
+        image: 'ghcr.io/linuxserver/htpcmanager'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/mcmyadmin.yml
+++ b/.pendingremake/mcmyadmin.yml
@@ -16,7 +16,7 @@
         pgrole: 'mcmyadmin'
         intport: '8080'
         extport: '8087'
-        image: 'linuxserver/mcmyadmin2'
+        image: 'ghcr.io/linuxserver/mcmyadmin2'
 
     - name: 'Including cron job'
       include_tasks: '/opt/communityapps/apps/_core.yml'

--- a/.pendingremake/medusa.yml
+++ b/.pendingremake/medusa.yml
@@ -16,7 +16,7 @@
         pgrole: "medusa"
         intport: "8081"
         extport: "8081"
-        image: "linuxserver/medusa"
+        image: "ghcr.io/linuxserver/medusa"
 
     - name: 'Including cron job'
       include_tasks: '/opt/communityapps/apps/_core.yml'

--- a/.pendingremake/muximux.yml
+++ b/.pendingremake/muximux.yml
@@ -15,7 +15,7 @@
         pgrole: 'muximux'
         intport: '80'
         extport: '8015'
-        image: 'linuxserver/muximux'
+        image: 'ghcr.io/linuxserver/muximux'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/mylar.yml
+++ b/.pendingremake/mylar.yml
@@ -15,7 +15,7 @@
         pgrole: 'mylar'
         intport: '8090'
         extport: '8090'
-        image: 'linuxserver/mylar'
+        image: 'ghcr.io/linuxserver/mylar'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/nextcloud.yml
+++ b/.pendingremake/nextcloud.yml
@@ -15,7 +15,7 @@
         pgrole: 'nextcloud'
         intport: '443'
         extport: '4645'
-        image: 'linuxserver/nextcloud'
+        image: 'ghcr.io/linuxserver/nextcloud'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'
@@ -50,7 +50,7 @@
     - name: Create and start nextcloud container
       docker_container:
         name: nextcloud
-        image: 'linuxserver/nextcloud'
+        image: 'ghcr.io/linuxserver/nextcloud'
         pull: yes
         published_ports:
           - '127.0.0.0.1:4645:443'

--- a/.pendingremake/nzbget-mp4.yml
+++ b/.pendingremake/nzbget-mp4.yml
@@ -20,7 +20,7 @@
         pgrole: 'nzbget'
         intport: '6789'
         extport: '6789'
-        image: 'linuxserver/nzbget'
+        image: 'ghcr.io/linuxserver/nzbget'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/radarr4k.yml
+++ b/.pendingremake/radarr4k.yml
@@ -16,7 +16,7 @@
         pgrole: 'radarr4k'
         intport: '7878'
         extport: '7874'
-        image: 'linuxserver/radarr'
+        image: 'ghcr.io/linuxserver/radarr'
 
     - name: 'Including cron job'
       include_tasks: '/opt/communityapps/apps/_core.yml'

--- a/.pendingremake/radarrhdr.yml
+++ b/.pendingremake/radarrhdr.yml
@@ -16,7 +16,7 @@
         pgrole: 'radarrhdr'
         intport: '7878'
         extport: '7877'
-        image: 'linuxserver/radarr'
+        image: 'ghcr.io/linuxserver/radarr'
 
     - name: 'Including cron job'
       include_tasks: '/opt/communityapps/apps/_core.yml'

--- a/.pendingremake/resilio.yml
+++ b/.pendingremake/resilio.yml
@@ -25,7 +25,7 @@
         extport: '8888'
         intport2: '55555'
         extport2: '55555'
-        image: 'linuxserver/resilio-sync'
+        image: 'ghcr.io/linuxserver/resilio-sync'
 
     # EXTRAS FOR RESILIO ##########################################################
     - name: 'Create {{pgrole}} script directories'

--- a/.pendingremake/sonarrhdr.yml
+++ b/.pendingremake/sonarrhdr.yml
@@ -16,7 +16,7 @@
         pgrole: 'sonarrhdr'
         intport: '8989'
         extport: '8987'
-        image: 'linuxserver/sonarr:preview'
+        image: 'ghcr.io/linuxserver/sonarr:preview'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/syncthing.yml
+++ b/.pendingremake/syncthing.yml
@@ -19,7 +19,7 @@
         extport2: '22000'
         intport3: '21027'
         extport3: '21027'
-        image: 'linuxserver/syncthing'
+        image: 'ghcr.io/linuxserver/syncthing'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/templates/broken/kodi-headless.yml
+++ b/.pendingremake/templates/broken/kodi-headless.yml
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Title:      PlexGuide (linuxserver/kodi-headless)
+# Title:      PlexGuide (ghcr.io/linuxserver/kodi-headless)
 # Author(s):  PlexGuide
 # URL:        https://plexguide.com - http://github.plexguide.com
 # GNU:        General Public License v3.0
@@ -19,7 +19,7 @@
         extport2: '9099'
         intport3: '9777'
         extport3: '9777/udp'
-        image: 'linuxserver/kodi-headless:latest'
+        image: 'ghcr.io/linuxserver/kodi-headless:latest'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/thelounge.yml
+++ b/.pendingremake/thelounge.yml
@@ -15,7 +15,7 @@
         pgrole: 'thelounge'
         intport: '9000'
         extport: '9100'
-        image: 'linuxserver/thelounge'
+        image: 'ghcr.io/linuxserver/thelounge'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/ubooquity.yml
+++ b/.pendingremake/ubooquity.yml
@@ -15,7 +15,7 @@
         pgrole: 'ubooquity'
         intport: '2202'
         extport: '2202'
-        image: 'linuxserver/ubooquity'
+        image: 'ghcr.io/linuxserver/ubooquity'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.pendingremake/unifi.yml
+++ b/.pendingremake/unifi.yml
@@ -25,7 +25,7 @@
         extport5: '8443'
         intport6: '8880/tcp'
         extport6: '8880'
-        image: 'linuxserver/unifi-controller:latest'
+        image: 'ghcr.io/linuxserver/unifi-controller:latest'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/.template_new
+++ b/.template_new
@@ -28,8 +28,8 @@ container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 # how users select an image; the 1st image is the default. If only 1, it's ok!
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/nzbget:latest
-linuxserver/nzbget:testing
+ghcr.io/linuxserver/nzbget:latest
+ghcr.io/linuxserver/nzbget:testing
 EOF
 
 # YML EXPORT ###################################################################

--- a/airsonic
+++ b/airsonic
@@ -21,7 +21,7 @@ container_permissions PUID 1000
 container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/airsonic:latest
+ghcr.io/linuxserver/airsonic:latest
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/bazarr
+++ b/bazarr
@@ -17,8 +17,8 @@ container_permissions PUID 1000
 container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/bazarr:latest
-linuxserver/bazarr:development
+ghcr.io/linuxserver/bazarr:latest
+ghcr.io/linuxserver/bazarr:development
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/beets
+++ b/beets
@@ -17,8 +17,8 @@ container_permissions PUID 1000
 container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/beets:latest
-linuxserver/beets:nightly
+ghcr.io/linuxserver/beets:latest
+ghcr.io/linuxserver/beets:nightly
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/dokuwiki
+++ b/dokuwiki
@@ -19,7 +19,7 @@ container_permissions PGID 1000
 
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/dokuwiki
+ghcr.io/linuxserver/dokuwiki
 EOF
 # YML EXPORT ###################################################################
 container_core

--- a/organizr
+++ b/organizr
@@ -16,7 +16,7 @@ container_permissions PUID 1000
 container_permissions PGID 1000
 # IMAGES EXPORT - 1ST IS DEFAULT ###############################################
 cat <<- EOF > "/pg/images/$pgrole.images"
-linuxserver/organizr:latest
+ghcr.io/linuxserver/organizr:latest
 organizrtools/organizr-v2:plex
 EOF
 # YML EXPORT ###################################################################


### PR DESCRIPTION
Changed linuxserver.io repository to the ghcr.io prefix per the linuxserver.io team due to the rate limits now being imposed by docker.com